### PR TITLE
Revise the jython script for timelapse movies

### DIFF
--- a/script/CARE_generic.py
+++ b/script/CARE_generic.py
@@ -20,7 +20,8 @@ from ij import IJ
 from ij.plugin import Duplicator
 import os
 
-def runNetwork(inputPath, outputPath, imp):
+def runNetwork(outputPath, imp):
+	inputPath = imp.getOriginalFileInfo().fileName
 	print("input: " + inputPath + ", output: " + outputPath)
 	mymod = (command.run(GenericNetwork, False,
 		"input", imp,
@@ -53,7 +54,7 @@ if inputPath.endswith(".tif"): # If processing a single .tif file
 		if nFrames > 1: # If there is only 1 specified .tif file but multiple frames
 			print("ERROR: To process an hyperstack with multiple frames, please provide a directory as output")
 			sys.exit()
-		runNetwork(inputPath, outputPath, impSource)
+		runNetwork(outputPath, impSource)
 
 	else:
 		print("Processing: " + input.getName())
@@ -68,7 +69,7 @@ if inputPath.endswith(".tif"): # If processing a single .tif file
 			outputFileName = root + "_frame" + str(frame) + ".tif"
 			# Run the network
 			print("Processing: " + outputFileName)
-			runNetwork(inputPath, os.path.join(outputPath, outputFileName), impSingleTp)
+			runNetwork(os.path.join(outputPath, outputFileName), impSingleTp)
 	
 elif input.isDirectory():
 	if outputPath.endswith(".tif"):
@@ -82,7 +83,7 @@ elif input.isDirectory():
 	for file in listOfFilesInFolder:
 		if file.getName().endswith(".tif"):
 			impSource = IJ.openImage(file.toString()) 
-			runNetwork(file.toString(), os.path.join(outputPath, file.getName()), impSource)
+			runNetwork(os.path.join(outputPath, file.getName()), impSource)
 
 else: # input is not a directory but not a .tif file either
 	print("ERROR: please provide a .tif file or directory for input")

--- a/script/CARE_generic.py
+++ b/script/CARE_generic.py
@@ -50,6 +50,9 @@ if inputPath.endswith(".tif"): # If processing a single .tif file
 		sys.exit()	
 
 	if outputPath.endswith(".tif"):
+		if nFrames > 1: # If there is only 1 specified .tif file but multiple frames
+			print("ERROR: To process an hyperstack with multiple frames, please provide a directory as output")
+			sys.exit()
 		runNetwork(inputPath, outputPath, impSource)
 
 	else:

--- a/script/CARE_generic.py
+++ b/script/CARE_generic.py
@@ -1,17 +1,17 @@
-# @String(label="Input path (.tif or folder with .tifs)", required=false, value='/home/random/Development/imagej/project/CSBDeep/script') input
-# @String(label="Output path (.tif or folder)", required=false, value='/home/random/Development/imagej/project/CSBDeep/script/out') output
-# @String(label="Model file", required=false, value='/home/random/Development/imagej/project/CSBDeep/data/Tobias Boothe/models/phago_C2_no_transform_model.zip') modelFile
-# @String(label="Model file", required=false, value='phago_C2_no_transform_model') _modelName
-# @Integer(label="Number of tiles", required=false, value=8) nTiles
-# @Integer(label="Tile overlap", required=false, value=32) overlap
-# @Boolean(label="Normalize input", required=false, value=true) normalizeInput
-# @Float(label="Bottom percentile", required=false, value=3.0, stepSize=0.1) percentileBottom
-# @Float(label="Top percentile", required=false, value=99.8, stepSize=0.1) percentileTop
-# @Boolean(label="Clip", required=false, value=false) clip
-# @Boolean(label="Show progress dialog", required=false, value=true) showProgressDialog
-# @DatasetIOService io
-# @CommandService command
-# @ModuleService module
+#@ File(label="Input path (.tif or folder with .tifs)", required=false, value='/home/random/Development/imagej/project/CSBDeep/script', style="both") input
+#@ File(label="Output path (.tif or folder)", required=false, value='/home/random/Development/imagej/project/CSBDeep/script/out', style="directory") output
+#@ File(label="Model file", required=false, value='/home/random/Development/imagej/project/CSBDeep/data/Tobias Boothe/models/phago_C2_no_transform_model.zip', style="file") modelFile
+#@ String(label="Model file", required=false, value='phago_C2_no_transform_model') _modelName
+#@ Integer(label="Number of tiles", required=false, value=8) nTiles
+#@ Integer(label="Tile overlap", required=false, value=32) overlap
+#@ Boolean(label="Normalize input", required=false, value=true) normalizeInput
+#@ Float(label="Bottom percentile", required=false, value=3.0, stepSize=0.1) percentileBottom
+#@ Float(label="Top percentile", required=false, value=99.8, stepSize=0.1) percentileTop
+#@ Boolean(label="Clip", required=false, value=false) clip
+#@ Boolean(label="Show progress dialog", required=false, value=true) showProgressDialog
+#@ DatasetIOService io
+#@ CommandService command
+#@ ModuleService module
 
 from java.io import File
 import sys
@@ -37,6 +37,10 @@ def runNetwork(inputPath, outputPath):
 	myoutput = mymod.getOutput("output")
 	print(myoutput)
 	io.save(myoutput, outputPath)
+
+
+input = str(input) # change object from file to str
+output = str(output)  # change object from file to str
 
 if input.endswith(".tif"):
 	if output.endswith(".tif"):

--- a/script/CARE_generic.py
+++ b/script/CARE_generic.py
@@ -1,17 +1,17 @@
-#@ File(label="Input path (.tif or folder with .tifs)", required=false, value='/home/random/Development/imagej/project/CSBDeep/script', style="both") input
-#@ File(label="Output path (.tif or folder)", required=false, value='/home/random/Development/imagej/project/CSBDeep/script/out', style="directory") output
-#@ File(label="Model file", required=false, value='/home/random/Development/imagej/project/CSBDeep/data/Tobias Boothe/models/phago_C2_no_transform_model.zip', style="file") modelFile
-#@ String(label="Model file", required=false, value='phago_C2_no_transform_model') _modelName
-#@ Integer(label="Number of tiles", required=false, value=8) nTiles
-#@ Integer(label="Tile overlap", required=false, value=32) overlap
-#@ Boolean(label="Normalize input", required=false, value=true) normalizeInput
-#@ Float(label="Bottom percentile", required=false, value=3.0, stepSize=0.1) percentileBottom
-#@ Float(label="Top percentile", required=false, value=99.8, stepSize=0.1) percentileTop
-#@ Boolean(label="Clip", required=false, value=false) clip
-#@ Boolean(label="Show progress dialog", required=false, value=true) showProgressDialog
-#@ DatasetIOService io
-#@ CommandService command
-#@ ModuleService module
+# @File(label="Input path (.tif or folder with .tifs)", required=false, value='/home/random/Development/imagej/project/CSBDeep/script', style="both") input
+# @File(label="Output path (.tif or folder)", required=false, value='/home/random/Development/imagej/project/CSBDeep/script/out', style="directory") output
+# @File(label="Model file", required=false, value='/home/random/Development/imagej/project/CSBDeep/data/Tobias Boothe/models/phago_C2_no_transform_model.zip', style="file") modelFile
+# @String(label="Model file", required=false, value='phago_C2_no_transform_model') _modelName
+# @Integer(label="Number of tiles", required=false, value=8) nTiles
+# @Integer(label="Tile overlap", required=false, value=32) overlap
+# @Boolean(label="Normalize input", required=false, value=true) normalizeInput
+# @Float(label="Bottom percentile", required=false, value=3.0, stepSize=0.1) percentileBottom
+# @Float(label="Top percentile", required=false, value=99.8, stepSize=0.1) percentileTop
+# @Boolean(label="Clip", required=false, value=false) clip
+# @Boolean(label="Show progress dialog", required=false, value=true) showProgressDialog
+# @DatasetIOService io
+# @CommandService command
+# @ModuleService module
 
 from java.io import File
 import sys
@@ -19,10 +19,6 @@ from de.csbdresden.csbdeep.commands import GenericNetwork
 from ij import IJ
 from ij.plugin import Duplicator
 import os
-
-def getFileName(path):
-	fileparts = path.split("/")
-	return fileparts[len(fileparts)-1]
 
 def runNetwork(inputPath, outputPath, imp):
 	print("input: " + inputPath + ", output: " + outputPath)
@@ -41,57 +37,50 @@ def runNetwork(inputPath, outputPath, imp):
 	io.save(myoutput, outputPath)
 
 
+inputPath = input.getPath() # Extract input file path
+outputPath = output.getPath()  # Extract output file path
 
-input = str(input) # change object from file to str
-output = str(output)  # change object from file to str
+if inputPath.endswith(".tif"): # If processing a single .tif file
+	
+	impSource = IJ.openImage(inputPath) 
 
-if input.endswith(".tif"):
-	if output.endswith(".tif"):
-		impSource = io.open(input)
-		runNetwork(input, output, impSource)
+	[width, height, nChannels, nSlices, nFrames] = impSource.getDimensions()
+	if nChannels > 1: # if more than 1 channel, exit
+		print("ERROR: please provide an image with a single channel")
+		sys.exit()	
+
+	if outputPath.endswith(".tif"):
+		runNetwork(inputPath, outputPath, impSource)
+
 	else:
-		if not(output.endswith("/")):
-			output += "/"
-
-		impSource = IJ.openImage(input)
-
-		[width, height, nChannels, nSlices, nFrames] = impSource.getDimensions()
-
-		if nChannels > 1: # if more than 1 channel, exit
-			print("ERROR: please provide an image with a single channel")
-			sys.exit()	
-
-		print("Processing: " + getFileName(input))
+		print("Processing: " + input.getName())
 		print("Found "+str(impSource.getNFrames())+" frames to process")
 
 		for dt in xrange(nFrames): # For each frame
-			 # Frames in the movie will begin at 1
-			frame = dt+1
+			frame = dt+1 # Frames in the movie will begin at 1
 			# Duplicate the frame of interest
 			impSingleTp = Duplicator().run(impSource, 1, 1, 1, nSlices, frame, frame)
 			# Create a new output fileName
-			root, ext = os.path.splitext(getFileName(input))
+			root, ext = os.path.splitext(input.getName())
 			outputFileName = root + "_frame" + str(frame) + ".tif"
 			# Run the network
 			print("Processing: " + outputFileName)
-			runNetwork(input, output + outputFileName, impSingleTp)
-
+			runNetwork(inputPath, os.path.join(outputPath, outputFileName), impSingleTp)
 	
-else:
-	if output.endswith(".tif"):
+elif input.isDirectory():
+	if outputPath.endswith(".tif"):
 		print("ERROR: please provide a directory as output, because your input is also a directory")
 		sys.exit()
-	if not(output.endswith("/")):
-		output += "/"
-	if not(input.endswith("/")):
-		input += "/"
-	if(output == input):
+	if(outputPath == inputPath):
 		print("ERROR: please provide an output directory that is not the same as the input directory")
 		sys.exit()
-	directory = File(input);
-	listOfFilesInFolder = directory.listFiles();
 
+	listOfFilesInFolder = input.listFiles();
 	for file in listOfFilesInFolder:
-		if file.toString().endswith(".tif"):
+		if file.getName().endswith(".tif"):
 			impSource = io.open(file.toString())
-			runNetwork(file.toString(), output + getFileName(file.toString()), impSource)
+			runNetwork(file.toString(), os.path.join(outputPath, file.getName()), impSource)
+
+else: # input is not a directory but not a .tif file either
+	print("ERROR: please provide a .tif file or directory for input")
+	sys.exit()

--- a/script/CARE_generic.py
+++ b/script/CARE_generic.py
@@ -81,7 +81,7 @@ elif input.isDirectory():
 	listOfFilesInFolder = input.listFiles();
 	for file in listOfFilesInFolder:
 		if file.getName().endswith(".tif"):
-			impSource = io.open(file.toString())
+			impSource = IJ.openImage(file.toString()) 
 			runNetwork(file.toString(), os.path.join(outputPath, file.getName()), impSource)
 
 else: # input is not a directory but not a .tif file either


### PR DESCRIPTION

This revision allows the user to select a multi-timepoint tif. 

The script automatically checks the number of timepoints in the .tif file and process each timepoint independently before saving each timepoint in an output folder with the extension _frameN appended to the original filename.

GUI file browsing to select the images and path handling are simplified

