### PR TITLE
Add network returning tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,10 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-plugins-io-table</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/de/csbdresden/csbdeep/commands/GenericCoreNetwork.java
+++ b/src/main/java/de/csbdresden/csbdeep/commands/GenericCoreNetwork.java
@@ -1,0 +1,687 @@
+/*-
+ * #%L
+ * CSBDeep: CNNs for image restoration of fluorescence microscopy.
+ * %%
+ * Copyright (C) 2017 - 2018 Deborah Schmidt, Florian Jug, Benjamin Wilhelm
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package de.csbdresden.csbdeep.commands;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import javax.swing.*;
+
+import org.scijava.Cancelable;
+import org.scijava.Disposable;
+import org.scijava.Initializable;
+import org.scijava.ItemIO;
+import org.scijava.app.StatusService;
+import org.scijava.command.Command;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.prefs.PrefService;
+import org.scijava.thread.ThreadService;
+import org.scijava.ui.UIService;
+import org.scijava.widget.Button;
+
+import de.csbdresden.csbdeep.io.DefaultInputProcessor;
+import de.csbdresden.csbdeep.io.InputProcessor;
+import de.csbdresden.csbdeep.io.OutputProcessor;
+import de.csbdresden.csbdeep.network.*;
+import de.csbdresden.csbdeep.network.model.Network;
+import de.csbdresden.csbdeep.network.model.tensorflow.TensorFlowNetwork;
+import de.csbdresden.csbdeep.normalize.DefaultInputNormalizer;
+import de.csbdresden.csbdeep.normalize.InputNormalizer;
+import de.csbdresden.csbdeep.task.Task;
+import de.csbdresden.csbdeep.task.TaskForceManager;
+import de.csbdresden.csbdeep.task.TaskManager;
+import de.csbdresden.csbdeep.tiling.*;
+import de.csbdresden.csbdeep.ui.MappingDialog;
+import de.csbdresden.csbdeep.util.IOHelper;
+import net.imagej.Dataset;
+import net.imagej.DatasetService;
+import net.imagej.axis.AxisType;
+import net.imagej.ops.OpService;
+import net.imagej.tensorflow.TensorFlowService;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.exception.IncompatibleTypeException;
+import net.imglib2.type.numeric.real.FloatType;
+
+@Plugin(type = Command.class, menuPath = "Plugins>CSBDeep>Run your network")
+public abstract class GenericCoreNetwork implements
+		Command, Cancelable, Initializable, Disposable
+{
+
+	@Parameter(type = ItemIO.INPUT, initializer = "input")
+	public Dataset input;
+
+	@Parameter
+	protected boolean normalizeInput = true;
+	@Parameter
+	protected float percentileBottom = 3.0f;
+	@Parameter
+	protected float percentileTop = 99.8f;
+
+	protected float min = 0;
+	protected float max = 1;
+
+	@Parameter(label = "Clip normalization")
+	protected boolean clip = false;
+
+	@Parameter(label = "Number of tiles", min = "1")
+	protected int nTiles = 8;
+
+	@Parameter(label = "Tile size has to be multiple of", min = "1")
+	protected int blockMultiple = 32;
+
+	@Parameter(label = "Overlap between tiles", min = "0", stepSize = "16")
+	protected int overlap = 32;
+
+
+	@Parameter(label = "Batch size", min = "1")
+	protected int batchSize = 1;
+
+	private boolean modelNeedsInitialization = false;
+	private boolean networkInitialized;
+	private boolean networkAndInputCompatible;
+
+	public enum NetworkInputSourceType { UNSET, FILE, URL }
+	
+	private NetworkInputSourceType networkInputSourceType = NetworkInputSourceType.UNSET;
+
+	@Parameter(label = "Import model (.zip)", callback = "modelFileChanged",
+			initializer = "modelFileInitialized", persist = false, required = false)
+	private File modelFile;
+
+	@Parameter(label = "Import model (.zip) from URL", callback = "modelUrlChanged",
+			initializer = "modelUrlChanged", persist = false, required = false)
+	protected String modelUrl;
+
+	@Parameter(label = "Adjust mapping of TF network input",
+			callback = "openTFMappingDialog")
+	private Button changeTFMapping;
+
+	@Parameter(label="Show progress dialog")
+	protected boolean showProgressDialog = true;
+
+	@Parameter
+	protected LogService log;
+
+	@Parameter
+	protected StatusService status;
+
+	@Parameter
+	protected TensorFlowService tensorFlowService;
+
+	@Parameter
+	protected DatasetService datasetService;
+
+	@Parameter
+	protected UIService uiService;
+
+	@Parameter
+	protected OpService opService;
+
+	@Parameter
+	private PrefService prefService;
+
+	@Parameter
+	private ThreadService threadService;
+
+	protected String modelName;
+
+	protected TaskManager taskManager;
+
+	protected Network network;
+	protected Tiling tiling;
+
+	protected InputProcessor inputProcessor;
+	protected InputValidator inputValidator;
+	protected InputMapper inputMapper;
+	protected InputNormalizer inputNormalizer;
+	protected InputTiler inputTiler;
+	protected ModelLoader modelLoader;
+	protected ModelExecutor modelExecutor;
+	protected OutputTiler outputTiler;
+	protected OutputProcessor outputProcessor;
+
+	protected boolean initialized = false;
+
+	private ExecutorService pool = null;
+	private Future<?> future;
+
+	protected String cacheName;
+	protected String modelFileKey;
+	private String modelFileUrl = "";
+
+	private int oldNTiles;
+	private int oldBatchesSize;
+
+	protected void openTFMappingDialog() {
+		threadService.run(() -> {
+			tryToInitialize();
+			solveModelSource();
+			initiateModelIfNeeded();
+			try {
+				threadService.invoke(() -> MappingDialog.create(network.getInputNode(), network.getOutputNode()));
+			} catch (InterruptedException | InvocationTargetException e) {
+				e.printStackTrace();
+			}
+		});
+	}
+
+	/** Executed whenever the {@link #modelFile} parameter is initialized. */
+	protected void modelFileInitialized() {
+		final String p_modelfile = prefService.get(this.getClass(), modelFileKey, "");
+		if (!p_modelfile.isEmpty()) {
+			modelFile = new File(p_modelfile);
+			if(modelFile.exists()) {
+				modelFileChanged();
+			}
+		}
+	}
+
+	private void updateCacheName() {
+		switch(networkInputSourceType) {
+			case UNSET:
+			default:
+				break;
+			case FILE:
+				cacheName = getFileCacheName(this.getClass(), modelFile);
+				if(cacheName != null) savePreferences();
+				break;
+			case URL:
+				cacheName = getUrlCacheName(this.getClass(), modelUrl);
+				if(cacheName != null) savePreferences();
+				break;
+		}
+	}
+
+	public static String getUrlCacheName(Class commandClass, String modelUrl) {
+		try {
+			return IOHelper.getUrlCacheName(commandClass, modelUrl);
+		} catch (IOException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	public static String getFileCacheName(Class commandClass, File modelFile) {
+		try {
+			return IOHelper.getFileCacheName(commandClass, modelFile);
+		} catch (IOException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	protected void modelFileChanged() {
+		if (modelFile != null) {
+			if(modelFile.exists()) {
+				modelUrl = null;
+				networkInputSourceType = NetworkInputSourceType.FILE;
+				modelFileUrl = modelFile.getAbsolutePath();
+				modelChanged();
+			}else {
+				error("Model file " + modelFile.getAbsolutePath() + " does not exist.");
+			}
+		}
+	}
+
+	protected void modelUrlChanged() {
+		if(modelUrl != null && modelUrl.length() > new String("https://").length()) {
+			if (IOHelper.urlExists(modelUrl)) {
+				modelFile = null;
+				networkInputSourceType = NetworkInputSourceType.URL;
+				modelFileUrl = modelUrl;
+				modelChanged();
+				return;
+			}
+		}
+	}
+
+	protected void modelChanged() {
+		updateCacheName();
+		modelNeedsInitialization = true;
+		savePreferences();
+		if (networkInitialized) {
+			network.clear();
+		}
+	}
+
+	protected void initiateModelIfNeeded() {
+		if(modelNeedsInitialization) {
+			try {
+				tryToPrepareInputAndNetwork();
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	@Override
+	public void initialize() {
+		initialized = true;
+		cacheName = this.getClass().getSimpleName();
+		modelFileKey = getModelFileKey();
+		initTasks();
+		initTaskManager();
+		initNetwork();
+	}
+
+	public String getModelFileKey() {
+		return this.getClass().getSimpleName() + "_modelfile";
+	}
+
+	protected void tryToInitialize() {
+		if (!initialized) {
+			initialize();
+		}
+	}
+
+	protected boolean initNetwork() {
+		networkInitialized = true;
+		network = new TensorFlowNetwork(tensorFlowService, datasetService,
+			modelExecutor);
+		if(network.libraryLoaded()) {
+			network.testGPUSupport();
+			if(!network.supportsGPU()) taskManager.noGPUFound();
+		}else {
+			return false;
+		}
+		return true;
+	}
+
+	protected void initTasks() {
+		inputValidator = initInputValidator();
+		inputMapper = initInputMapper();
+		inputProcessor = initInputProcessor();
+		inputNormalizer = initInputNormalizer();
+		inputTiler = initInputTiler();
+		modelLoader = initModelLoader();
+		modelExecutor = initModelExecutor();
+		outputTiler = initOutputTiler();
+		outputProcessor = initOutputProcessor();
+	}
+
+	protected void initTaskManager() {
+		final TaskForceManager tfm = new TaskForceManager(isHeadless() || !showProgressDialog, log, status, threadService);
+		tfm.initialize();
+		tfm.createTaskForce("Preprocessing", modelLoader, inputValidator, inputMapper,
+			inputProcessor, inputNormalizer);
+		tfm.createTaskForce("Tiling", inputTiler);
+		tfm.createTaskForce("Execution", modelExecutor);
+		tfm.createTaskForce("Postprocessing", outputTiler, outputProcessor);
+		taskManager = tfm;
+	}
+
+	protected InputValidator initInputValidator() {
+		return new DefaultInputValidator();
+	}
+
+	protected InputMapper initInputMapper() {
+		return new DefaultInputMapper();
+	}
+
+	protected InputProcessor initInputProcessor() {
+		return new DefaultInputProcessor();
+	}
+
+	protected InputNormalizer initInputNormalizer() {
+		return new DefaultInputNormalizer();
+	}
+
+	protected InputTiler initInputTiler() {
+		return new DefaultInputTiler();
+	}
+
+	protected ModelLoader initModelLoader() {
+		return new DefaultModelLoader();
+	}
+
+	protected ModelExecutor initModelExecutor() {
+		return new DefaultModelExecutor();
+	}
+
+	protected OutputTiler initOutputTiler() {
+		return new DefaultOutputTiler();
+	}
+
+	protected abstract OutputProcessor initOutputProcessor();
+
+	protected void initTiling() {
+		tiling = new DefaultTiling(nTiles, batchSize, blockMultiple, overlap);
+	}
+
+	public void run() {
+
+		final long startTime = System.currentTimeMillis();
+
+		if (noInputData()) return;
+
+		pool = Executors.newSingleThreadExecutor();
+
+		try {
+
+			future = pool.submit(this::mainThread);
+			if(future != null) future.get();
+
+		} catch (OutOfMemoryError | InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+		}
+
+		dispose();
+
+		log("CSBDeep plugin exit (took " + (System.currentTimeMillis() - startTime) + " milliseconds)");
+
+	}
+
+	protected void mainThread() throws OutOfMemoryError {
+
+		tryToInitialize();
+		taskManager.finalizeSetup();
+		solveModelSource();
+
+		updateCacheName();
+		savePreferences();
+
+		initiateModelIfNeeded();
+		if(!networkAndInputCompatible) return;
+
+		final Dataset normalizedInput;
+		if (doInputNormalization()) {
+			setupNormalizer();
+			normalizedInput = inputNormalizer.run(getInput(), opService,
+					datasetService);
+		} else {
+			normalizedInput = getInput();
+		}
+
+		System.out.println("normalized input first element: " + normalizedInput.firstElement());
+
+		final List<RandomAccessibleInterval> processedInput = inputProcessor.run(
+				normalizedInput, network);
+
+		log("INPUT NODE: ");
+		network.getInputNode().printMapping(inputProcessor);
+		log("OUTPUT NODE: ");
+		network.getOutputNode().printMapping(inputProcessor);
+
+		initTiling();
+		List<AdvancedTiledView<FloatType>> tiledOutput = null;
+		try {
+			tiledOutput = tryToTileAndRunNetwork(processedInput);
+		} catch (ExecutionException e) {
+			e.printStackTrace();
+		}
+		if(tiledOutput != null) {
+			final List<RandomAccessibleInterval<FloatType>> output;
+			if(network.getOutputNode().getTilingAllowed()) {
+				output = outputTiler.run(
+						tiledOutput, tiling, network.getOutputNode().getFinalAxesArray());
+			} else {
+				output = tiledOutput.stream().map(tile -> getSingleTile(tile)).collect(Collectors.toList());
+			}
+			for (AdvancedTiledView obj : tiledOutput) {
+				obj.dispose();
+			}
+			computeOutput(output);
+		}
+
+	}
+
+	protected abstract void computeOutput(List<RandomAccessibleInterval<FloatType>> output);
+
+	private RandomAccessibleInterval<FloatType> getSingleTile(AdvancedTiledView<FloatType> tile) {
+		return tile.getProcessedTiles().get(0);
+	}
+
+	private void solveModelSource() {
+		if(modelFileUrl.isEmpty()) modelFileChanged();
+		if(modelFileUrl.isEmpty()) modelUrlChanged();
+	}
+
+	protected void setupNormalizer() {
+		((DefaultInputNormalizer) inputNormalizer).getNormalizer().setup(
+				new float[] { percentileBottom, percentileTop }, new float[] { min,
+						max }, clip);
+	}
+
+	protected boolean doInputNormalization() {
+		return normalizeInput;
+	}
+
+	protected void tryToPrepareInputAndNetwork() throws FileNotFoundException {
+
+		networkAndInputCompatible = false;
+
+		modelName = cacheName;
+
+		if(!networkInitialized) {
+			initNetwork();
+		}
+		if(!network.libraryLoaded()) return;
+
+		if(modelFileUrl.isEmpty()) {
+			taskManager.logError("Trained model file / URL is missing or unavailable");
+		}
+		modelLoader.run(modelName, network, modelFileUrl, getInput());
+
+		try {
+			inputValidator.run(getInput(), network);
+		}
+		catch(IncompatibleTypeException e) {
+			taskManager.logError(e.getMessage());
+			return;
+		}
+		inputMapper.run(getInput(), network);
+		networkAndInputCompatible = !inputMapper.isFailed();
+	}
+
+	private void savePreferences() {
+		if(modelFile != null) {
+			prefService.put(this.getClass(), modelFileKey, modelFile.getAbsolutePath());
+		}
+	}
+
+	@Override
+	public void dispose() {
+		if (taskManager != null) {
+			taskManager.close();
+		}
+		if (network != null) {
+			network.dispose();
+		}
+		if(pool != null) {
+			pool.shutdown();
+		}
+		pool = null;
+	}
+
+	protected List<AdvancedTiledView<FloatType>> tryToTileAndRunNetwork(
+		final List<RandomAccessibleInterval> normalizedInput)
+			throws OutOfMemoryError, ExecutionException {
+		List<AdvancedTiledView<FloatType>> tiledOutput = null;
+
+		boolean isOutOfMemory = true;
+		boolean canHandleOutOfMemory = true;
+
+		while (isOutOfMemory && canHandleOutOfMemory) {
+			try {
+				tiledOutput = tileAndRunNetwork(normalizedInput);
+				isOutOfMemory = false;
+			}
+			catch (final OutOfMemoryError e) {
+				isOutOfMemory = true;
+				canHandleOutOfMemory = tryHandleOutOfMemoryError();
+			}
+		}
+
+		if (isOutOfMemory) throw new OutOfMemoryError(
+			"Out of memory exception occurred. Plugin exit.");
+
+		return tiledOutput;
+	}
+
+	protected List tileAndRunNetwork(List<RandomAccessibleInterval> input) throws ExecutionException {
+		AxisType[] finalInputAxes = network.getInputNode().getFinalAxesArray();
+		Tiling.TilingAction[] tilingActions = network.getInputNode().getTilingActions();
+		final List<AdvancedTiledView> tiledInput;
+		if(network.getInputNode().getTilingAllowed()) {
+			tiledInput = inputTiler.run(
+					input, finalInputAxes, tiling, tilingActions);
+			nTiles = tiling.getTilesNum();
+		} else {
+			tiledInput = input.stream().map(image -> getSingleTileView(image, finalInputAxes)).collect(Collectors.toList());
+		}
+		if(tiledInput == null) return null;
+		return modelExecutor.run(tiledInput, network);
+	}
+
+	private AdvancedTiledView getSingleTileView(RandomAccessibleInterval image, AxisType[] finalInputAxes) {
+		long[] blockSize = new long[image.numDimensions()];
+		long[] overlap = new long[image.numDimensions()];
+		for (int i = 0; i < blockSize.length; i++) {
+			blockSize[i] = image.dimension(i);
+			overlap[i] = 0;
+		}
+		return new AdvancedTiledView(image, blockSize, overlap, finalInputAxes);
+	}
+
+	public void setMapping(final AxisType[] mapping) {
+		inputMapper.setMapping(mapping);
+	}
+
+	public AxisType[] getMapping() {
+		return inputMapper.getMapping();
+	}
+
+	private boolean noInputData() {
+		boolean noInput = getInput() == null;
+		if(noInput) {
+			if(isHeadless()) {
+				log("Please open an image first");
+			}else {
+				showError("Please open an image first");
+			}
+		}
+		return noInput;
+	}
+
+	private boolean tryHandleOutOfMemoryError() {
+		// We expect it to be an out of memory exception and
+		// try it again with more tiles or smaller batches.
+		final Task modelExecutorTask = modelExecutor;
+		nTiles = tiling.getTilesNum();
+		if(oldNTiles == nTiles && oldBatchesSize == batchSize) {
+			modelExecutorTask.setFailed();
+			return false;
+		}
+		oldNTiles = nTiles;
+		oldBatchesSize = batchSize;
+
+		handleOutOfMemoryError();
+		initTiling();
+		nTiles = tiling.getTilesNum();
+		modelExecutorTask.logWarning(
+			"Out of memory exception occurred. Trying with " + nTiles +
+				" tiles, batch size " + batchSize + " and overlap " + overlap + "...");
+
+		modelExecutorTask.startNewIteration();
+		inputTiler.addIteration();
+		return true;
+	}
+
+	protected void handleOutOfMemoryError() {
+		batchSize /= 2;
+		if (batchSize < 1) {
+			batchSize = 1;
+			nTiles *= 2;
+		}
+	}
+
+	protected static void showError(final String errorMsg) {
+		JOptionPane.showMessageDialog(null, errorMsg, "Error",
+			JOptionPane.ERROR_MESSAGE);
+	}
+
+	public Dataset getInput() {
+		return input;
+	}
+
+	@Override
+	public String getCancelReason() {
+		return null;
+	}
+
+	@Override
+	public boolean isCanceled() {
+		return false;
+	}
+
+	@Override
+	public void cancel(final String reason) {
+		if(future != null) {
+			future.cancel(true);
+		}
+		if(pool != null) {
+			pool.shutdownNow();
+		}
+		dispose();
+	}
+
+	protected void log(final String msg) {
+		if (taskManager != null) {
+			taskManager.log(msg);
+		}
+		else {
+			System.out.println(msg);
+		}
+	}
+
+	protected void error(final String msg) {
+		if (taskManager != null) {
+			taskManager.logError(msg);
+		}
+		else {
+			System.out.println("[ERROR] " + msg);
+		}
+	}
+
+	protected boolean isHeadless() {
+		return uiService.isHeadless();
+	}
+
+}

--- a/src/main/java/de/csbdresden/csbdeep/commands/GenericIsotropicNetwork.java
+++ b/src/main/java/de/csbdresden/csbdeep/commands/GenericIsotropicNetwork.java
@@ -45,8 +45,8 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 import de.csbdresden.csbdeep.imglib2.TiledView;
+import de.csbdresden.csbdeep.io.DatasetOutputProcessor;
 import de.csbdresden.csbdeep.io.DefaultInputProcessor;
-import de.csbdresden.csbdeep.io.DefaultOutputProcessor;
 import de.csbdresden.csbdeep.io.InputProcessor;
 import de.csbdresden.csbdeep.io.OutputProcessor;
 import de.csbdresden.csbdeep.network.model.ImageTensor;
@@ -102,7 +102,7 @@ public class GenericIsotropicNetwork<T extends RealType<T>> extends GenericNetwo
 
 	@Override
 	protected OutputProcessor initOutputProcessor() {
-		return new IsoOutputProcessor();
+		return new IsoOutputProcessor(datasetService, input);
 	}
 
 	private class IsoInputProcessor extends DefaultInputProcessor
@@ -168,13 +168,18 @@ public class GenericIsotropicNetwork<T extends RealType<T>> extends GenericNetwo
 	}
 
 	private class IsoOutputProcessor<T extends RealType<T> & NativeType<T>>
-		extends DefaultOutputProcessor<T>
+		extends DatasetOutputProcessor<T>
 	{
 
+		private final Dataset dataset;
+
+		public IsoOutputProcessor(DatasetService datasetService, Dataset input) {
+			super(datasetService);
+			this.dataset = input;
+		}
+
 		@Override
-		public Dataset run(final List<RandomAccessibleInterval<T>> result,
-			final Dataset dataset, final ImageTensor node,
-			final DatasetService datasetService)
+		public Dataset run(final List<RandomAccessibleInterval<T>> result, final ImageTensor node)
 		{
 			setStarted();
 

--- a/src/main/java/de/csbdresden/csbdeep/commands/GenericTableNetwork.java
+++ b/src/main/java/de/csbdresden/csbdeep/commands/GenericTableNetwork.java
@@ -2,7 +2,7 @@
  * #%L
  * CSBDeep: CNNs for image restoration of fluorescence microscopy.
  * %%
- * Copyright (C) 2017 - 2018 Deborah Schmidt, Florian Jug, Benjamin Wilhelm
+ * Copyright (C) 2017 - 2019 Deborah Schmidt, Florian Jug, Benjamin Wilhelm
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -36,29 +36,32 @@ import org.scijava.ItemIO;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.table.GenericTable;
 
-import de.csbdresden.csbdeep.io.DatasetOutputProcessor;
 import de.csbdresden.csbdeep.io.OutputProcessor;
+import de.csbdresden.csbdeep.io.TableOutputProcessor;
 import net.imagej.Dataset;
 import net.imagej.ImageJ;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.real.FloatType;
 
-@Plugin(type = Command.class, menuPath = "Plugins>CSBDeep>Run your network")
-public class GenericNetwork extends GenericCoreNetwork {
+@Plugin(type = Command.class, headless = true)
+public class GenericTableNetwork extends GenericCoreNetwork {
 
 	@Parameter(type = ItemIO.OUTPUT)
-	protected Dataset output;
+	protected GenericTable output;
 
 	@Override
 	protected OutputProcessor initOutputProcessor() {
-		return new DatasetOutputProcessor(datasetService);
+		return new TableOutputProcessor();
 	}
 
 	@Override
 	protected void computeOutput(List<RandomAccessibleInterval<FloatType>> output) {
-		this.output = (Dataset) outputProcessor.run(output, network.getOutputNode());
+
+		this.output = (GenericTable) outputProcessor.run(output, network.getOutputNode());
 	}
+
 
 	/**
 	 * This main function serves for development purposes. It allows you to run
@@ -88,7 +91,7 @@ public class GenericNetwork extends GenericCoreNetwork {
 			ij.ui().show(dataset);
 
 			// invoke the plugin
-			ij.command().run(GenericNetwork.class, true);
+			ij.command().run(GenericTableNetwork.class, true);
 		}
 
 	}

--- a/src/main/java/de/csbdresden/csbdeep/io/DatasetOutputProcessor.java
+++ b/src/main/java/de/csbdresden/csbdeep/io/DatasetOutputProcessor.java
@@ -15,22 +15,24 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.Views;
 
-public class DefaultOutputProcessor<T extends RealType<T> & NativeType<T>>
-	extends DefaultTask implements OutputProcessor<T>
+public class DatasetOutputProcessor<T extends RealType<T> & NativeType<T>>
+	extends DefaultTask implements OutputProcessor<T, Dataset>
 {
 
 	public static String[] OUTPUT_NAMES = { "result" };
+	private final DatasetService datasetService;
+
+	public DatasetOutputProcessor(DatasetService datasetService) {
+		this.datasetService = datasetService;
+	}
 
 	@Override
-	public Dataset run(final List<RandomAccessibleInterval<T>> result,
-		final Dataset dataset, final ImageTensor node,
-		final DatasetService datasetService)
+	public Dataset run(final List<RandomAccessibleInterval<T>> result, final ImageTensor node)
 	{
 		setStarted();
 
 		final List<Dataset> output = new ArrayList<>();
-		result.forEach(image -> output.addAll(_run(image, node,
-			datasetService)));
+		result.forEach(image -> output.addAll(_run(image, node)));
 
 		setFinished();
 
@@ -39,8 +41,7 @@ public class DefaultOutputProcessor<T extends RealType<T> & NativeType<T>>
 		return output.get(0);
 	}
 
-	private List<Dataset> _run(RandomAccessibleInterval<T> result,
-	                           final ImageTensor node, DatasetService datasetService)
+	private List<Dataset> _run(RandomAccessibleInterval<T> result, final ImageTensor node)
 	{
 
 		final List<Dataset> output = new ArrayList<>();
@@ -51,9 +52,15 @@ public class DefaultOutputProcessor<T extends RealType<T> & NativeType<T>>
 			List<Integer> droppedDims = node.dropSingletonDims();
 			result = dropSingletonDimensions(result, droppedDims);
 
-			log("Displaying " + OUTPUT_NAMES[0] + " image..");
-			output.add(wrapIntoDataset(OUTPUT_NAMES[0], result,
-				node.getAxesArray(), datasetService));
+			if(result.numDimensions() > 1) {
+				log("Displaying " + OUTPUT_NAMES[0] + " image..");
+				output.add(wrapIntoDataset(OUTPUT_NAMES[0], result,
+						node.getAxesArray(), datasetService));
+			} else {
+				log("Displaying " + OUTPUT_NAMES[0] + " table..");
+
+			}
+
 			return output;
 		}
 

--- a/src/main/java/de/csbdresden/csbdeep/io/OutputProcessor.java
+++ b/src/main/java/de/csbdresden/csbdeep/io/OutputProcessor.java
@@ -5,15 +5,11 @@ import java.util.List;
 
 import de.csbdresden.csbdeep.network.model.ImageTensor;
 import de.csbdresden.csbdeep.task.Task;
-import net.imagej.Dataset;
-import net.imagej.DatasetService;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.RealType;
 
-public interface OutputProcessor<T extends RealType<T>> extends Task {
+public interface OutputProcessor<T extends RealType<T>, O> extends Task {
 
-	Dataset run(final List<RandomAccessibleInterval<T>> result,
-	            final Dataset datasetView, final ImageTensor node,
-	            final DatasetService datasetService);
+	O run(final List<RandomAccessibleInterval<T>> result, final ImageTensor node);
 
 }

--- a/src/main/java/de/csbdresden/csbdeep/io/TableOutputProcessor.java
+++ b/src/main/java/de/csbdresden/csbdeep/io/TableOutputProcessor.java
@@ -1,0 +1,34 @@
+package de.csbdresden.csbdeep.io;
+
+import java.util.List;
+
+import org.scijava.table.DefaultGenericTable;
+import org.scijava.table.GenericTable;
+
+import de.csbdresden.csbdeep.network.model.ImageTensor;
+import de.csbdresden.csbdeep.task.DefaultTask;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+
+public class TableOutputProcessor<T extends RealType<T>> extends DefaultTask implements OutputProcessor<T, GenericTable> {
+
+		@Override
+		public GenericTable run(List<RandomAccessibleInterval<T>> result, ImageTensor node) {
+
+			RandomAccessibleInterval data = result.get(0);
+			GenericTable table = new DefaultGenericTable();
+			table.setColumnCount((int) Math.max(1, data.dimension(1)));
+			table.setRowCount((int) Math.max(1, data.dimension(0)));
+			RandomAccess<T> ra = data.randomAccess();
+			for (int i = 0; i < data.dimension(0); i++) {
+				for (int j = 0; j < data.dimension(1); j++) {
+					ra.setPosition(i, 0);
+					ra.setPosition(j, 1);
+					table.set(j, i, ra.get().copy());
+				}
+			}
+
+			return table;
+		}
+	}

--- a/src/main/java/de/csbdresden/csbdeep/network/model/ImageTensor.java
+++ b/src/main/java/de/csbdresden/csbdeep/network/model/ImageTensor.java
@@ -1,9 +1,9 @@
 
 package de.csbdresden.csbdeep.network.model;
 
-import static java.lang.Math.max;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -18,21 +18,20 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 
-// TODO rename
 public class ImageTensor {
 
 	private class Dimension {
-		public Dimension(AxisType type, long size) {
+
+		Dimension(AxisType type, long size) {
 			this.type = type;
 			this.size = size;
 		}
+
 		private AxisType type;
 		private long size;
-
 		public long getSize() {
 			return size;
 		}
-
 		public AxisType getType() {
 			return type;
 		}
@@ -40,18 +39,21 @@ public class ImageTensor {
 		public String toString() {
 			return "(" + type + ", " + size + ")";
 		}
-	}
 
+
+	}
 	// I do not use the following line because it was returning the axes in a
 	// different order in different setups
 	// AxisType[] axes = Axes.knownTypes();
+
 	AxisType[] availableAxes = { Axes.X, Axes.Y, Axes.Z, Axes.TIME,
 		Axes.CHANNEL };
-
 	private String name;
+
 	private List<Dimension> image;
 	private List<Dimension> node;
 	private final List<Integer> finalMapping = new ArrayList<>();
+	private boolean tilingAllowed = true;
 
 	public ImageTensor() {
 	}
@@ -71,7 +73,7 @@ public class ImageTensor {
 		}
 	}
 
-	public void setNode(long[] dimensions, AxisType[] axisTypes) {
+	void setNode(long[] dimensions, AxisType[] axisTypes) {
 		if(node != null) node.clear();
 		else node = new ArrayList<>();
 		for (int i = 0; i < dimensions.length; i++) {
@@ -234,7 +236,7 @@ public class ImageTensor {
 		return (long) 1;
 	}
 
-	public Integer getDatasetDimIndexByNodeIndex(final int nodeDim) {
+	private Integer getDatasetDimIndexByNodeIndex(final int nodeDim) {
 		if (node.size() > nodeDim) {
 			final AxisType axis = node.get(nodeDim).getType();
 			for (int i = 0; i < image.size(); i++) {
@@ -251,10 +253,10 @@ public class ImageTensor {
 		return null;
 	}
 
-	public Integer getNodeDimByDatasetDim(final int datasetDim) {
+	private Integer getNodeDimByDatasetDim(final int datasetDim) {
 		if (image.size() > datasetDim) {
 			for (int i = 0; i < node.size(); i++) {
-				if(node.get(i).getType().equals(image.get(datasetDim).getType())) return i;
+				if(node.get(i).getType() != null && node.get(i).getType().equals(image.get(datasetDim).getType())) return i;
 			}
 		}
 		return -1;
@@ -343,7 +345,7 @@ public class ImageTensor {
 
 	private boolean imageHasChannel() {
 		for(Dimension d : image) {
-			if(d.type.equals(Axes.CHANNEL)) return true;
+			if(d != null && d.type != null && d.type.equals(Axes.CHANNEL)) return true;
 		}
 		return false;
 	}
@@ -368,7 +370,7 @@ public class ImageTensor {
 		return imgActions;
 	}
 
-	public boolean isImageDimUseless(int index) {
+	private boolean isImageDimUseless(int index) {
 		return image.size() <= index || image.get(index).size == 1L;
 	}
 
@@ -388,6 +390,14 @@ public class ImageTensor {
 			}
 		}
 		return res;
+	}
+
+	public void setTilingAllowed(boolean allowed) {
+		this.tilingAllowed = allowed;
+	}
+
+	public boolean getTilingAllowed() {
+		return tilingAllowed;
 	}
 
 }

--- a/src/test/java/de/csbdresden/csbdeep/commands/GenericTableNetworkTest.java
+++ b/src/test/java/de/csbdresden/csbdeep/commands/GenericTableNetworkTest.java
@@ -1,0 +1,43 @@
+
+package de.csbdresden.csbdeep.commands;
+
+import static junit.framework.TestCase.assertNotNull;
+
+import java.io.File;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Test;
+import org.scijava.module.Module;
+import org.scijava.table.GenericTable;
+
+import de.csbdresden.csbdeep.CSBDeepTest;
+import net.imagej.Dataset;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imglib2.type.numeric.real.FloatType;
+
+public class GenericTableNetworkTest extends CSBDeepTest {
+
+	@Test
+	public void testGenericNetwork() {
+		launchImageJ();
+
+		URL networkUrl = this.getClass().getResource("denoise2D/model.zip");
+
+		final Dataset input = createDataset(new FloatType(), new long[] { 3, 3, 3 }, new AxisType[] {
+				Axes.X, Axes.Y, Axes.Z });
+
+		try {
+			final Module module = ij.command().run(GenericTableNetwork.class,
+					false, "input", input, "modelFile", new File(networkUrl.getPath())).get();
+			GenericTable output = (GenericTable) module.getOutput("output");
+			assertNotNull(output);
+			System.out.println(output);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR introduces a `GenericTableNetwork` which returns a `GenericTable` instead of a `Dataset`.

@HedgehogCode do you have an opinion on the structural changes? Since `GenericNetwork` was returning `Dataset` and is used in other peoples Java code / scripts, I did not want to change that, so I introduced an abstract `GenericCoreNetwork` class where everything from `GenericNetwork` moved to except the output parameter. 

The `GenericTableNetwork` assumes the network output is singular and has 2 dimensions. Any additional dimensions will be ignored.

These are the changes in this PR:
* upgrade to `pom-scijava 27.0.1`
* add `scijava-plugins-io-table` dependency
* rename `DefaultOutputProcessor` to `DatasetOutputProcessor`
* add `TableOutputProcessor`
* move everything but the `output` parameter from `GenericNetwork` to `GenericCoreNetwork`
* make `GenericNetwork` extending `GenericCoreNetwork` with `Dataset output`
parameter
* create `GenericTableNetwork` extending `GenericCoreNetwork` with
`GenericTable output` parameter
* `GenericCoreNetwork`: add `protected computeOutput` method
* change signature of `OutputProcessor::run`
* ImageTensor: add tilingAllowed attribute
* `ImageTensor`: make a few methods private